### PR TITLE
CSS-Mem-Slider

### DIFF
--- a/cssMemSlider/index.html
+++ b/cssMemSlider/index.html
@@ -49,9 +49,9 @@
         <div class="slider__text">
             <div class="text_slides">
                 <div class="text_slide"><p>Everyone makes mistakes...</p></div>
-                <div class="text_slide"><p>BAD EGG</p></div>
+                <div class="text_slide"><p>BAD EGG.</p></div>
                 <div class="text_slide"><p>The HTML doesn't need to load JS and CSS...if the HTML and CSS are in JS.</p></div>
-                <div class="text_slide"><p>The modern web, it's so funny</p></div>
+                <div class="text_slide"><p>The modern web, it's so funny.</p></div>
             </div>
         </div>
     </div>

--- a/cssMemSlider/style.css
+++ b/cssMemSlider/style.css
@@ -6,7 +6,6 @@
 
 body {
     display: flex;
-    align-items: center;
     justify-content: center;
     
     height: 100vh;
@@ -205,7 +204,6 @@ input[type="radio"] {
             "text text pagination";
         row-gap: 20px;
         padding: 1em;
-        /* min-height: max-content; */
         height: 90vh;
     }
 
@@ -238,7 +236,6 @@ input[type="radio"] {
         min-height: 20vh;
         max-height: 80vh;
         padding: 1em;
-
     }
 
     .slider__pagination .slider__pagintaion_dot {

--- a/cssMemSlider/style.css
+++ b/cssMemSlider/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
+
 * {
     box-sizing: border-box;
     padding: 0;
@@ -71,6 +73,8 @@ input[type="radio"] {
     line-height: 1.5rem;
     font-weight: 400;
     color: #fff;
+    opacity: 0;
+    transition: all .5s ease-in-out; 
 }
 
 .slider__pagination {
@@ -94,7 +98,7 @@ input[type="radio"] {
     height: 1em;
     cursor: pointer;
     border-radius: 100%;
-    border: 2px solid #71abfe;
+    border: .125rem solid #71abfe;
     background: transparent;
     transition: all .3s ease-in-out;
 }
@@ -115,7 +119,7 @@ input[type="radio"] {
 
 .slider__pagination .slider__pagintaion_dot:active {
     background: #313d4e;
-    border: 2px solid #002558;
+    border: .125rem solid #002558;
     transition: all .01s linear;
 }
 
@@ -130,10 +134,15 @@ input[type="radio"] {
 #input-3:checked ~ .slider__text .text_slides { margin-left:-200%; }
 #input-4:checked ~ .slider__text .text_slides { margin-left:-300%; }
 
-#input-1:checked ~ .slider__pagination .slider__pagintaion_dot:nth-child(1) { opacity: 1; background: #71abfe; }
-#input-2:checked ~ .slider__pagination .slider__pagintaion_dot:nth-child(2) { opacity: 1; background: #71abfe; }
-#input-3:checked ~ .slider__pagination .slider__pagintaion_dot:nth-child(3) { opacity: 1; background: #71abfe; }
-#input-4:checked ~ .slider__pagination .slider__pagintaion_dot:nth-child(4) { opacity: 1; background: #71abfe; }
+#input-1:checked ~ .slider__text .text_slides .text_slide:nth-child(1) { opacity: 1; }
+#input-2:checked ~ .slider__text .text_slides .text_slide:nth-child(2) { opacity: 1; }
+#input-3:checked ~ .slider__text .text_slides .text_slide:nth-child(3) { opacity: 1; }
+#input-4:checked ~ .slider__text .text_slides .text_slide:nth-child(4) { opacity: 1; }
+
+#input-1:checked ~ .slider__pagination .slider__pagintaion_dot:nth-child(1) { background: #71abfe; }
+#input-2:checked ~ .slider__pagination .slider__pagintaion_dot:nth-child(2) { background: #71abfe; }
+#input-3:checked ~ .slider__pagination .slider__pagintaion_dot:nth-child(3) { background: #71abfe; }
+#input-4:checked ~ .slider__pagination .slider__pagintaion_dot:nth-child(4) { background: #71abfe; }
 
 /* ===== * MOBILE STYLES * ===== */
 @media screen and (max-width: 720px) {
@@ -153,7 +162,7 @@ input[type="radio"] {
             "layout"
             "pagination"
             "text";
-        row-gap: 0px;
+        row-gap: 0;
     }
 
     .slider__pagination {
@@ -169,7 +178,7 @@ input[type="radio"] {
     .text_slide {
         font-size: 1.8rem;
         line-height: 2.3rem;
-        padding: 10px;
+        padding: 1em;
     }
 
     .slider__pagination nav {
@@ -195,7 +204,7 @@ input[type="radio"] {
 
     .slider_container {
         grid-template-columns: repeat(3, 1fr);
-        grid-template-rows: repeat(4, 1fr) 100px;
+        grid-template-rows: repeat(4, 1fr) 5%;
         grid-template-areas: 
             "layout layout layout"
             "layout layout layout"
@@ -225,7 +234,7 @@ input[type="radio"] {
     }
     .slider_container {
         grid-template-columns: repeat(3, 1fr);
-        grid-template-rows: repeat(3, 1fr) 150px;
+        grid-template-rows: repeat(3, 1fr) 20%;
         grid-template-areas: 
             "layout layout layout"
             "layout layout layout"


### PR DESCRIPTION
1. Task: https://github.com/DrDiman/CSS-Mem-Slider
2. <details>
    <summary>Screenshot</summary>
    <img src="https://i.imgur.com/91gJQF0.jpg" width="500">
    </details>
3. Deploy: https://shadowinhaze.github.io/cssMemSlider/cssMemSlider/index.html
4. Done 16.10.2021 / deadline 17.10.2021
5. Score: 150 / 150
    - breakpoints: 720px (switch to mobile version of slider with one column layout) -> 1024px -> 1440px
    - commits with date stamp, two branches with PR.  +30
      - commits list: https://github.com/shadowinhaze/cssMemSlider/commits/gh-pages
    - slider centered +10
    - layout from the task  +10
    - image slides change with animation +20
    - text slides change with animation +10
    - text slides are strings +15
    - pagination points have ::after for better interactive  +5
    - pagination points have :hover, :active effects and different style for "active" state +10
    - mobile version of slider (see the first point with breakpoints) +20
    - there are no stable (px) values in the css +10
    - there are no "position: absolute" in the css +10
    - project uses **google fonts**! It's not a mistake! Mems are in assets folder!
